### PR TITLE
Add tests for multitargeting scenarios

### DIFF
--- a/tests/fsharpqa/Source/MultiTargeting/InlineCoreResource_author.fs
+++ b/tests/fsharpqa/Source/MultiTargeting/InlineCoreResource_author.fs
@@ -1,0 +1,4 @@
+module Test
+
+let inline init1 n f = Array.init n f
+let init2 n f = Array.init n f

--- a/tests/fsharpqa/Source/MultiTargeting/InlineCoreResource_consumer.fsx
+++ b/tests/fsharpqa/Source/MultiTargeting/InlineCoreResource_consumer.fsx
@@ -1,0 +1,12 @@
+#if INTERACTIVE
+#r "author.dll"
+#else
+module Foo
+#endif
+
+Test.init1 4 (fun _ -> 4.) |> printfn "%A"
+Test.init2 4 (fun _ -> 4.) |> printfn "%A"
+
+#if INTERACTIVE
+#q ;;
+#endif

--- a/tests/fsharpqa/Source/MultiTargeting/env.lst
+++ b/tests/fsharpqa/Source/MultiTargeting/env.lst
@@ -6,3 +6,4 @@ NOMONO	SOURCE=E_BadPathToFSharpCore.fsx             SCFLAGS="--noframework -r %W
 NOMONO	SOURCE=E_UseBinaryIncompatibleLibrary.fs     SCFLAGS="--noframework -r ..\\Common\\FSharp.Core.dll"	# E_UseBinaryIncompatibleLibrary.fs
 
 ReqOpen	SOURCE=dummy.fs  POSTCMD="\$FSI_PIPE --nologo --quiet --exec .\\MultiTargetMatrix.fsx   QuotedCommaTypeName_author.fs QuotedCommaTypeName_consumer.fsx 0,8"		#  QuotedCommaTypeName
+ReqOpen	SOURCE=dummy.fs  POSTCMD="\$FSI_PIPE --nologo --quiet --exec .\\MultiTargetMatrix.fsx   InlineCoreResource_author.fs InlineCoreResource_consumer.fsx"		#  InlineCoreResource


### PR DESCRIPTION
Add a failing test which exercises a bunch of cross-version scenarios.

Before your fix: all of the scenarios where 3.1 is targeted by the library, then redirected up to 4.0 are failing

After your fix: all pass
